### PR TITLE
Implementar cadastro de paciente

### DIFF
--- a/back/CHANGELOG.md
+++ b/back/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+### Added
+* [#13](https://github.com/gustavoreino/sistema-pews/issues/13) - Implementar cadastro de pacientes

--- a/back/infra/docker-compose.yml
+++ b/back/infra/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: dpage/pgadmin4
     container_name: pgadmin4_container
     environment:
-      - PGADMIN_DEFAULT_EMAIL=pgadmin
+      - PGADMIN_DEFAULT_EMAIL=pgadmin@gmail.com
       - PGADMIN_DEFAULT_PASSWORD=pgadmin
     ports:
       - "4000:80"

--- a/back/pom.xml
+++ b/back/pom.xml
@@ -54,6 +54,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
 	</dependencies>
 
 	<build>

--- a/back/src/main/java/utfpr/edu/bcc3004/pews/controller/PatientController.java
+++ b/back/src/main/java/utfpr/edu/bcc3004/pews/controller/PatientController.java
@@ -1,0 +1,29 @@
+package utfpr.edu.bcc3004.pews.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+
+import utfpr.edu.bcc3004.pews.model.Patient;
+import utfpr.edu.bcc3004.pews.service.PatientService;
+
+@RestController
+@RequestMapping("/api/pacientes")
+public class PatientController {
+
+  @Autowired
+  private PatientService patientService;
+
+  @PostMapping
+  public ResponseEntity<?> save(@RequestBody @Valid Patient patient, BindingResult result) {
+    if (result.hasErrors()) {
+      return ResponseEntity.badRequest().body(result.getAllErrors());
+    }
+
+    Patient res = patientService.save(patient);
+    return ResponseEntity.status(HttpStatus.CREATED).body(res);
+  }
+}

--- a/back/src/main/java/utfpr/edu/bcc3004/pews/model/Patient.java
+++ b/back/src/main/java/utfpr/edu/bcc3004/pews/model/Patient.java
@@ -1,0 +1,79 @@
+package utfpr.edu.bcc3004.pews.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+
+import java.util.Date;
+
+@Entity
+public class Patient {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @NotNull(message = "Nome não pode ser nulo.")
+  private String name;
+
+  @NotNull(message = "Data de nascimento não pode ser nula.")
+  @Past(message = "Data de nascimento deve ser no passado.")
+  private Date birthdate;
+
+  private String cpf;
+
+  private String phone;
+
+  private String diagnosis;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Date getBirthdate() {
+    return birthdate;
+  }
+
+  public void setBirthdate(Date birthdate) {
+    this.birthdate = birthdate;
+  }
+
+  public String getCpf() {
+    return cpf;
+  }
+
+  public void setCpf(String cpf) {
+    this.cpf = cpf;
+  }
+
+  public String getPhone() {
+    return phone;
+  }
+
+  public void setPhone(String phone) {
+    this.phone = phone;
+  }
+
+  public String getDiagnosis() {
+    return diagnosis;
+  }
+
+  public void setDiagnosis(String diagnosis) {
+    this.diagnosis = diagnosis;
+  }
+}

--- a/back/src/main/java/utfpr/edu/bcc3004/pews/repository/PatientRepository.java
+++ b/back/src/main/java/utfpr/edu/bcc3004/pews/repository/PatientRepository.java
@@ -1,0 +1,11 @@
+package utfpr.edu.bcc3004.pews.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import utfpr.edu.bcc3004.pews.model.Patient;
+
+@Repository
+public interface PatientRepository extends JpaRepository<Patient, Long> {
+  Patient findByCpf(String cpf);
+}

--- a/back/src/main/java/utfpr/edu/bcc3004/pews/service/PatientService.java
+++ b/back/src/main/java/utfpr/edu/bcc3004/pews/service/PatientService.java
@@ -12,7 +12,7 @@ public class PatientService {
   @Autowired
   private PatientRepository patientRepository;
 
-  public Patient save(Patient paciente) {
-    return patientRepository.save(paciente);
+  public Patient save(Patient patient) {
+    return patientRepository.save(patient);
   }
 }

--- a/back/src/main/java/utfpr/edu/bcc3004/pews/service/PatientService.java
+++ b/back/src/main/java/utfpr/edu/bcc3004/pews/service/PatientService.java
@@ -1,0 +1,18 @@
+package utfpr.edu.bcc3004.pews.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import utfpr.edu.bcc3004.pews.repository.PatientRepository;
+import utfpr.edu.bcc3004.pews.model.Patient;
+
+@Service
+public class PatientService {
+
+  @Autowired
+  private PatientRepository patientRepository;
+
+  public Patient save(Patient paciente) {
+    return patientRepository.save(paciente);
+  }
+}


### PR DESCRIPTION
## Descrição
Nessa _issue_ foi implementado o cadastro de pacientes.


## Contexto
- **motivação:** Implementar cadastro de paciente

closes #13 

### Exemplo de body
```json
{
	"name": "John Doe",
        "birthdate": "2000-01-20",
        "cpf": "123.456.789-00",
        "phone": "(11) 98765-4321",
	"diagnosis": "Something"
}
```

## Como testar
### Escritor
- [x] A rota `POST /api/pacientes` está funcionando:
	- [x] As validações estão funcionando:
		- [x] Caso o nome seja vazio lança uma exceção `400 BAD REQUEST`
		- [x] Caso a data de nascimento seja no passado lança uma exceção `400 BAD REQUEST`
		- [x] Caso a data de nascimento seja vazia lança uma exceção `400 BAD REQUEST`

### Tester
- [x] A rota `POST /api/pacientes` está funcionando:
	- [x] As validações estão funcionando:
		- [x] Caso o nome seja vazio lança uma exceção `400 BAD REQUEST`
		- [x] Caso a data de nascimento seja no passado lança uma exceção `400 BAD REQUEST`
		- [x] Caso a data de nascimento seja vazia lança uma exceção `400 BAD REQUEST`

## Natureza da alteração
- [x] Nova Feature.
- [ ] Correção de BUG.
- [ ] Refatoração de Código.