### PR TITLE
Implementar listagem de pacientes

### DIFF
--- a/back/CHANGELOG.md
+++ b/back/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
 
 ### Added
+* [#14](https://github.com/gustavoreino/sistema-pews/issues/14) - Implementar listagem de pacientes
 * [#13](https://github.com/gustavoreino/sistema-pews/issues/13) - Implementar cadastro de pacientes

--- a/back/src/main/java/utfpr/edu/bcc3004/pews/controller/PatientController.java
+++ b/back/src/main/java/utfpr/edu/bcc3004/pews/controller/PatientController.java
@@ -7,6 +7,9 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 
+import java.util.List;
+import java.util.Optional;
+
 import utfpr.edu.bcc3004.pews.model.Patient;
 import utfpr.edu.bcc3004.pews.service.PatientService;
 
@@ -16,6 +19,23 @@ public class PatientController {
 
   @Autowired
   private PatientService patientService;
+
+  @GetMapping
+  public List<Patient> list() {
+    return patientService.findAll();
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<Patient> findById(@PathVariable Long id) {
+    Optional<Patient> patient = patientService.findById(id);
+    return patient.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+  }
+
+  @GetMapping("/cpf/{cpf}")
+  public ResponseEntity<Patient> findByCpf(@PathVariable String cpf) {
+    Patient patient = patientService.findByCpf(cpf);
+    return patient != null ? ResponseEntity.ok(patient) : ResponseEntity.notFound().build();
+  }
 
   @PostMapping
   public ResponseEntity<?> save(@RequestBody @Valid Patient patient, BindingResult result) {

--- a/back/src/main/java/utfpr/edu/bcc3004/pews/service/PatientService.java
+++ b/back/src/main/java/utfpr/edu/bcc3004/pews/service/PatientService.java
@@ -3,6 +3,9 @@ package utfpr.edu.bcc3004.pews.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Optional;
+
 import utfpr.edu.bcc3004.pews.repository.PatientRepository;
 import utfpr.edu.bcc3004.pews.model.Patient;
 
@@ -15,4 +18,17 @@ public class PatientService {
   public Patient save(Patient patient) {
     return patientRepository.save(patient);
   }
+
+  public List<Patient> findAll() {
+    return patientRepository.findAll();
+  }
+
+  public Optional<Patient> findById(Long id) {
+    return patientRepository.findById(id);
+  }
+
+  public Patient findByCpf(String cpf) {
+    return patientRepository.findByCpf(cpf);
+  }
+
 }


### PR DESCRIPTION
## Descrição
Nessa _issue_ foi implementado o cadastro de pacientes.


## Contexto
- **motivação:** Implementar listagem de pacientes

closes #14

## Como testar
### Escritor
- [x] A rota `GET /api/pacientes` retorna os pacientes cadastrados.
- [x] A rota `GET /api/pacientes/{id}` retorna o paciente identificado pelo ``id``, `404 NOT FOUND` caso contrário.
- [x] A rota `GET /api/pacientes/cpf/{cpf}` retorna o paciente identificado pelo ``cpf``, `404 NOT FOUND` caso contrário.

### Tester
- [ ] A rota `GET /api/pacientes` retorna os pacientes cadastrados.
- [ ] A rota `GET /api/pacientes/{id}` retorna o paciente identificado pelo ``id``, `404 NOT FOUND` caso contrário.
- [ ] A rota `GET /api/pacientes/cpf/{cpf}` retorna o paciente identificado pelo ``cpf``, `404 NOT FOUND` caso contrário.

## Natureza da alteração
- [x] Nova Feature.
- [ ] Correção de BUG.
- [ ] Refatoração de Código.