### PR TITLE
Implementar modificação de cadastro de paciente

### DIFF
--- a/back/CHANGELOG.md
+++ b/back/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
 ### Added
+* [#15](https://github.com/gustavoreino/sistema-pews/issues/15) - Implementar modificação de cadastro de paciente
 * [#14](https://github.com/gustavoreino/sistema-pews/issues/14) - Implementar listagem de pacientes
 * [#13](https://github.com/gustavoreino/sistema-pews/issues/13) - Implementar cadastro de pacientes

--- a/back/src/main/java/utfpr/edu/bcc3004/pews/controller/PatientController.java
+++ b/back/src/main/java/utfpr/edu/bcc3004/pews/controller/PatientController.java
@@ -46,4 +46,17 @@ public class PatientController {
     Patient res = patientService.save(patient);
     return ResponseEntity.status(HttpStatus.CREATED).body(res);
   }
+
+  @PatchMapping("/{id}")
+  public ResponseEntity<Patient> update(@PathVariable Long id, @RequestBody @Valid Patient patient) {
+
+    Patient updatedPatient = patientService.update(id, patient);
+
+    if (updatedPatient == null) {
+      return ResponseEntity.notFound().build();
+    }
+
+    return ResponseEntity.status(HttpStatus.OK).body(updatedPatient);
+  }
+
 }

--- a/back/src/main/java/utfpr/edu/bcc3004/pews/service/PatientService.java
+++ b/back/src/main/java/utfpr/edu/bcc3004/pews/service/PatientService.java
@@ -31,4 +31,32 @@ public class PatientService {
     return patientRepository.findByCpf(cpf);
   }
 
+
+  public Patient update(Long id, Patient patientUpdatedData) {
+    Optional<Patient> entry = patientRepository.findById(id);
+
+    if (entry.isEmpty()) {
+      return null;
+    }
+
+    Patient patient = entry.get();
+
+    if (patientUpdatedData.getName() != null) {
+      patient.setName(patientUpdatedData.getName());
+    }
+    if (patientUpdatedData.getBirthdate() != null) {
+      patient.setBirthdate(patientUpdatedData.getBirthdate());
+    }
+    if (patientUpdatedData.getCpf() != null) {
+      patient.setCpf(patientUpdatedData.getCpf());
+    }
+    if (patientUpdatedData.getPhone() != null) {
+      patient.setPhone(patientUpdatedData.getPhone());
+    }
+    if (patientUpdatedData.getDiagnosis() != null) {
+      patient.setDiagnosis(patientUpdatedData.getPhone());
+    }
+
+    return patientRepository.save(patient);
+  }
 }


### PR DESCRIPTION
## Descrição
Nessa _issue_ foi implementado a modificação de cadastro de paciente.


## Contexto
- **motivação:** Implementar listagem de pacientes

closes #15

## Como testar
### Escritor
- [x] A rota `PATCH /api/pacientes/{id}` atualiza o paciente.
- [x] As validações funcionam:
	- [x] Não é possível atualizar o cadastro caso o valor do campo ``cpf`` já exista.

### Tester
- [x] A rota `PATCH /api/pacientes/{id}` atualiza o paciente.
- [x] As validações funcionam:
	- [x] Não é possível atualizar o cadastro caso o valor do campo ``cpf`` já exista.

## Natureza da alteração
- [x] Nova Feature.
- [ ] Correção de BUG.
- [ ] Refatoração de Código.